### PR TITLE
Initialise variables used in drawing code

### DIFF
--- a/src/BPMLFO.cpp
+++ b/src/BPMLFO.cpp
@@ -102,7 +102,7 @@ struct LowFrequencyOscillator {
 	SchmittTrigger clockTrigger,resetTrigger,holdTrigger;
 	float divisions[DIVISIONS] = {1/64.0,1/32.0,1/16.0,1/13.0,1/11.0,1/8.0,1/7.0,1/6.0,1/5.0,1/4.0,1/3.0,1/2.0,1/1.5,1,1.5,2,3,4,5,6,7,8,11,13,16,32,64};
 	const char* divisionNames[DIVISIONS] = {"/64","/32","/16","/13","/11","/8","/7","/6","/5","/4","/3","/2","/1.5","x 1","x 1.5","x 2","x 3","x 4","x 5","x 6","x 7","x 8","x 11","x 13","x 16","x 32","x 64"};
-	int division;
+	int division = 0;
 	float time = 0.0;
 	float duration = 0;
 	bool holding = false;

--- a/src/BPMLFO2.cpp
+++ b/src/BPMLFO2.cpp
@@ -107,7 +107,7 @@ struct LowFrequencyOscillator {
 	SchmittTrigger clockTrigger,resetTrigger,holdTrigger;
 	float divisions[DIVISIONS] = {1/64.0,1/32.0,1/16.0,1/13.0,1/11.0,1/8.0,1/7.0,1/6.0,1/5.0,1/4.0,1/3.0,1/2.0,1/1.5,1,1.5,2,3,4,5,6,7,8,11,13,16,32,64};
 	const char* divisionNames[DIVISIONS] = {"/64","/32","/16","/13","/11","/8","/7","/6","/5","/4","/3","/2","/1.5","x 1","x 1.5","x 2","x 3","x 4","x 5","x 6","x 7","x 8","x 11","x 13","x 16","x 32","x 64"};
-	int division;
+	int division = 0;
 	float time = 0.0;
 	float duration = 0;
 	float waveshape = 0;


### PR DESCRIPTION
Module variables used in draw() need to be initialised to sensible values, otherwise if a module is added when the engine is paused, it will crash (or show garbage).